### PR TITLE
Add time type

### DIFF
--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type optionFunc func(f *Flag, option, value string) error
@@ -18,6 +19,9 @@ var (
 			"description": description,
 			"obligatory":  obligatory,
 			"mutexgroup":  mutexgroup,
+		},
+		reflect.TypeOf(new(time.Time)).Elem(): optionMap{
+			"format": time_format,
 		},
 		reflect.TypeOf(new(*os.File)).Elem(): optionMap{
 			"create": initOptionMeta(file_create, "file_mode", 0),
@@ -110,6 +114,11 @@ func file_perm(f *Flag, option, value string) error {
 		return err
 	}
 	f.optionMeta["file_perm"] = uint32(perm)
+	return nil
+}
+
+func time_format(f *Flag, option, value string) error {
+	f.optionMeta["format"] = value
 	return nil
 }
 

--- a/valueparser.go
+++ b/valueparser.go
@@ -26,6 +26,7 @@ var (
 		reflect.TypeOf(new(*net.TCPAddr)).Elem():  tcpAddrValueParser,
 		reflect.TypeOf(new(*url.URL)).Elem():      urlValueParser,
 		reflect.TypeOf(new(time.Duration)).Elem(): durationValueParser,
+		reflect.TypeOf(new(time.Time)).Elem():     timeValueParser,
 	}
 )
 
@@ -145,6 +146,15 @@ func urlValueParser(f *Flag, val string) (reflect.Value, error) {
 
 func durationValueParser(f *Flag, val string) (reflect.Value, error) {
 	d, err := time.ParseDuration(val)
+	return reflect.ValueOf(d), err
+}
+
+func timeValueParser(f *Flag, val string) (reflect.Value, error) {
+	format := time.RFC3339
+	if altFormat, ok := f.optionMeta["format"]; ok {
+		format = altFormat.(string)
+	}
+	d, err := time.Parse(format, val)
 	return reflect.ValueOf(d), err
 }
 

--- a/valueparser_test.go
+++ b/valueparser_test.go
@@ -87,3 +87,26 @@ func TestParse_Duration(t *testing.T) {
 		t.Fatalf("Unexpected value: %#v", options.Cache)
 	}
 }
+
+func TestParse_Time(t *testing.T) {
+	var args []string
+	var err error
+	var fs *FlagSet
+	var options struct {
+		DefaultFormat time.Time `goptions:"-d"`
+		AltFormat     time.Time `goptions:"-a, format='02-Jan-06-15:04--0700'"`
+	}
+
+	args = []string{"-d", "2006-01-02T17:04:05Z", "-a", "02-Jan-06-15:04--0700"}
+	fs = NewFlagSet("goptions", &options)
+	err = fs.Parse(args)
+	if err != nil {
+		t.Fatalf("Parsing failed: %s", err)
+	}
+	if got := options.DefaultFormat.Format(time.RFC3339); got != "2006-01-02T17:04:05Z" {
+		t.Fatalf("Unexpected value: %#v", got)
+	}
+	if got := options.AltFormat.Format(time.RFC3339); got != "2006-01-02T15:04:00-07:00" {
+		t.Fatalf("Unexpected value: %#v", got)
+	}
+}


### PR DESCRIPTION
Adds support for `time.Time` values, default in `RFC3339`, can be set.

